### PR TITLE
Fix small bug on Schema.php

### DIFF
--- a/system/database/schema.php
+++ b/system/database/schema.php
@@ -92,7 +92,7 @@ class Schema
         switch ($driver) {
             case 'mysql':
                 $query = 'SELECT column_name FROM information_schema.columns '.
-                    'WHERE table_schema = '.$database.' AND column_name = '.$column;
+                    'WHERE table_schema = '.$database.' AND table_name = '.$table.' AND column_name = '.$column;
                 break;
 
             case 'pgsql':


### PR DESCRIPTION
### Deskripsi
Schema.php has_column() method in mysql driver didn't  return correct result on MySQL 8.X
because the select query isn't specific for a table but database instead



### Cara mencoba
  1. var_dump(Schema::has_column('users','id'));


### Ceklis:
Tambahkan `x` pada kotak - kotak yang sesuai.

**Jenis perubahan:**
  - [x] Perbaikan/penambahan fitur tanpa memutus kompatibilitas
  - [ ] BC-break (perubahan yang memutus komaptibilitas dengan versi terdahulu)

**Lainnya:**
  - [ ] Gaya penulisan kode saya sudah mengikuti standar rakit.
  - [ ] Perubahan ini juga memerlukan perubahan pada dokumentasi.
  - [ ] Dokumentasi sudah saya perbarui.
