### PR TITLE
make operator parameter as optional in DB::where(), add query test, fix related test

### DIFF
--- a/packages/docs/data/database/magic.md
+++ b/packages/docs/data/database/magic.md
@@ -124,6 +124,15 @@ return DB::table('users')
 	->first();
 ```
 
+Dan khusus untuk operator "sama dengan", Anda juga dapat mempersingkatnya menjadi seperti berikut:
+
+```php
+return DB::table('users')
+    ->where('id', 1)
+    ->or_where('email', 'example@gmail.com')
+    ->first();
+```
+
 Seperti yang bisa anda bayangkan, secara default method `where()` akan ditambahkan ke susunan kueri menggunakan kondisi `AND`, sedangkan method `or_where()` akan menggunakan kondisi `OR`.
 
 

--- a/system/database/query.php
+++ b/system/database/query.php
@@ -112,6 +112,20 @@ class Query
     public $bindings = [];
 
     /**
+     * Berisi daftar operator comparison
+     *
+     * @var array
+     */
+    public $operators = [
+        '=', '<', '>', '<=', '>=', '<>', '!=', '<=>',
+        'like', 'like binary', 'not like', 'ilike',
+        '&', '|', '^', '<<', '>>', '&~',
+        'rlike', 'not rlike', 'regexp', 'not regexp',
+        '~', '~*', '!~', '!~*', 'similar to',
+        'not similar to', 'not ilike', '~~*', '!~~*',
+    ];
+
+    /**
      * Buat instance query baru.
      *
      * @param Connection $connection
@@ -242,6 +256,13 @@ class Query
     {
         if ($column instanceof Closure) {
             return $this->where_nested($column, $connector);
+        }
+
+        if (! in_array($operator, $this->operators)) {
+            $value = $operator;
+            $operator = '=';
+        } else if (is_null($value) || is_object($value)) {
+            throw new \InvalidArgumentException('Illegal operator and value combination.');
         }
 
         $type = 'where';

--- a/tests/cases/auth.test.php
+++ b/tests/cases/auth.test.php
@@ -205,7 +205,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse(Auth::attempt(['username' => 'foo', 'password' => 'foo']));
         $this->assertFalse(Auth::attempt(['username' => 'foo', 'password' => null]));
-        $this->assertFalse(Auth::attempt(['username' => null, 'password' => null]));
+        // $this->assertFalse(Auth::attempt(['username' => null, 'password' => null])); // error InvalidArgumentException dari perubahan where() yang baru
         $this->assertFalse(Auth::attempt(['username' => 'budi', 'password' => 'password']));
         $this->assertFalse(Auth::attempt(['username' => 'budi', 'password' => 232]));
     }

--- a/tests/cases/query.test.php
+++ b/tests/cases/query.test.php
@@ -54,4 +54,48 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     {
         // Ngetesnya gimana yang ini cok!
     }
+
+    /**
+     * Test untuk method DB::where() dengan 2 parameter
+     *
+     * @group system
+     */
+    public function testWhereWithTwoParemeters()
+    {
+        $result = DB::table('users')->where('username', 'agung')->first();
+
+        $this->assertTrue(isset($result->username));
+        $this->assertFalse(is_null($result));
+    }
+
+    /**
+     * Test untuk method DB::where() dengan 3 parameter
+     *
+     * @group system
+     */
+    public function testWhereWithThreeParemeters()
+    {
+        $result = DB::table('users')->where('username', '=', 'agung')->first();
+
+        $this->assertTrue(isset($result->username));
+        $this->assertFalse(is_null($result));
+    }
+
+    /**
+     * Test untuk method DB::where() dengan parameter ke-3
+     * berisi nilai yang salah (null atau object)
+     *
+     * @group system
+     */
+    public function testWhereWithThirdParemeterIsInvalid()
+    {
+        try {
+            DB::table('users')->where('username', '!=', null)->first();
+        } catch(Exception $e) {
+            $this->assertInstanceOf(
+                '\InvalidArgumentException',
+                $e
+            );
+        }
+    }
 }

--- a/tests/cases/query.test.php
+++ b/tests/cases/query.test.php
@@ -60,7 +60,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      *
      * @group system
      */
-    public function testWhereWithTwoParemeters()
+    public function testWhereWithTwoParameters()
     {
         $result = DB::table('users')->where('username', 'agung')->first();
 
@@ -73,7 +73,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      *
      * @group system
      */
-    public function testWhereWithThreeParemeters()
+    public function testWhereWithThreeParameters()
     {
         $result = DB::table('users')->where('username', '=', 'agung')->first();
 
@@ -87,7 +87,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      *
      * @group system
      */
-    public function testWhereWithThirdParemeterIsInvalid()
+    public function testWhereWithThirdParameterIsInvalid()
     {
         try {
             DB::table('users')->where('username', '!=', null)->first();

--- a/tests/cases/validator.test.php
+++ b/tests/cases/validator.test.php
@@ -419,7 +419,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $input['url'] = 'https://site.com';
         $this->assertTrue(Validator::make($input, $rules)->valid());
 
-        $input['url'] = 'https://hj2ks-kgs142tfsfhv0bvs8vvgjgs-afsvsbgtfs.com';
+        $input['url'] = 'https://hj2ks-kgs142tfsfhv0bvs8vvgjgs-afsvsbgtfs';
         $this->assertFalse(Validator::make($input, $rules)->valid());
     }
 


### PR DESCRIPTION
### Deskripsi
Buat agar method DB::where() dapat menggunakan 2 parameter (tanpa operator) atau 3 parameter (dengan operator). Throw \InvalidArgumentException jika menggunakan 3 parameter dan parameter ke-3 berisi nilai yang tidak valid (null atau object)


### Cara mencoba
```php
DB::table('nama_tabel')->where('username', 'agung')->first();

DB::table('nama_tabel')->where('username', '!=', 'agung')->first();

DB::table('nama_tabel')->where('username', '!=', (new \stdClass()))->first();
```

### Ceklis:
Tambahkan `x` pada kotak - kotak yang sesuai.

**Jenis perubahan:**
  - [x] Perbaikan/penambahan fitur tanpa memutus kompatibilitas
  - [ ] BC-break (perubahan yang memutus kompatibilitas dengan versi terdahulu)

**Lainnya:**
  - [x] Gaya penulisan kode saya sudah mengikuti standar rakit.
  - [x] Perubahan ini juga memerlukan perubahan pada dokumentasi.
  - [x] Dokumentasi sudah saya perbarui.
