### PR TITLE
fix: Notice: undefined index 'autoboot'

### DIFF
--- a/system/boot.php
+++ b/system/boot.php
@@ -82,7 +82,7 @@ unset($debugger, $template);
 */
 
 foreach (Package::$packages as $package => $config) {
-    if ($config['autoboot']) {
+    if (isset($config['autoboot']) && $config['autoboot']) {
         Package::boot($package);
     }
 }


### PR DESCRIPTION
### Deskripsi
Perbaikan pada error `Notice: Undefined index: autoboot in C:\laragon\www\rakit\system\boot.php on line 85`


### Ceklis:
Tambahkan `x` pada kotak - kotak yang sesuai.

**Jenis perubahan:**
  - [x] Perbaikan/penambahan fitur tanpa memutus kompatibilitas
  - [ ] BC-break (perubahan yang memutus kompatibilitas dengan versi terdahulu)

**Lainnya:**
  - [x] Gaya penulisan kode saya sudah mengikuti standar rakit.
  - [ ] Perubahan ini juga memerlukan perubahan pada dokumentasi.
  - [ ] Dokumentasi sudah saya perbarui.
